### PR TITLE
hide documentation for function aliases

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,8 @@ Documentation for the libzfs_core
 
 .. automodule:: libzfs_core
    :members:
+   :exclude-members: lzc_snap, lzc_recv, lzc_destroy_one,
+       lzc_inherit, lzc_set_props, lzc_list
 
 Documentation for the libzfs_core exceptions
 ********************************************


### PR DESCRIPTION
First, we hide the doc-string based documentation for aliases
that are not public.  We also hide the documentation for
convenience short aliases, so that the doc-strings are not
reproduced twice.
