### PR TITLE
C lzc_list() actually returns ENOENT if the dataset does not exist

### DIFF
--- a/libzfs_core/_error_translation.py
+++ b/libzfs_core/_error_translation.py
@@ -470,6 +470,8 @@ def lzc_list_snaps_translate_error(ret, name):
 def lzc_list_translate_error(ret, name, opts):
     if ret == 0:
         return
+    if ret == errno.ENOENT:
+        raise lzc_exc.DatasetNotFound(name)
     if ret == errno.EINVAL:
         _validate_fs_or_snap_name(name)
     raise _generic_exception(ret, name, "Error obtaining a list")

--- a/libzfs_core/_libzfs_core.py
+++ b/libzfs_core/_libzfs_core.py
@@ -870,6 +870,7 @@ def lzc_list(name, options):
     :return: a pair of file descriptors the first of which can be
              used to read the listing.
     :rtype: tuple of (int, int)
+    :raises DatasetNotFound: if the dataset does not exist.
 
     Two options are currently available:
 
@@ -1041,6 +1042,7 @@ def lzc_list_children(name):
     :return: an iterator that produces the names of the children.
     :raises NameInvalid: if the dataset name is invalid.
     :raises NameTooLong: if the dataset name is too long.
+    :raises DatasetNotFound: if the dataset does not exist.
 
     .. warning::
         If the dataset does not exist, then the returned iterator would produce
@@ -1067,6 +1069,7 @@ def lzc_list_snaps(name):
     :return: an iterator that produces the names of the snapshots.
     :raises NameInvalid: if the dataset name is invalid.
     :raises NameTooLong: if the dataset name is too long.
+    :raises DatasetNotFound: if the dataset does not exist.
 
     .. warning::
         If the dataset does not exist, then the returned iterator would produce

--- a/libzfs_core/test/test_libzfs_core.py
+++ b/libzfs_core/test/test_libzfs_core.py
@@ -3021,8 +3021,8 @@ class ZFSTest(unittest.TestCase):
     def test_list_children_nonexistent(self):
         fs = ZFSTest.pool.makeName("nonexistent")
 
-        children = list(lzc.lzc_list_children(fs))
-        self.assertEqual(children, [])
+        with self.assertRaises(lzc_exc.DatasetNotFound):
+            list(lzc.lzc_list_children(fs))
 
     @needs_support(lzc.lzc_list_children)
     def test_list_children_of_snap(self):
@@ -3052,8 +3052,8 @@ class ZFSTest(unittest.TestCase):
     def test_list_snaps_nonexistent(self):
         fs = ZFSTest.pool.makeName("nonexistent")
 
-        snaps = list(lzc.lzc_list_snaps(fs))
-        self.assertEqual(snaps, [])
+        with self.assertRaises(lzc_exc.DatasetNotFound):
+            list(lzc.lzc_list_snaps(fs))
 
     @needs_support(lzc.lzc_list_snaps)
     def test_list_snaps_of_snap(self):


### PR DESCRIPTION
The previous assumption was made based on the current behavior of
ZFS_IOC_DATASET_LIST_NEXT and ZFS_IOC_SNAPSHOT_LIST_NEXT ioctls.
