### PR TITLE
lzc_snaprange_space can return EXDEV

### DIFF
--- a/libzfs_core/_error_translation.py
+++ b/libzfs_core/_error_translation.py
@@ -168,6 +168,11 @@ def lzc_destroy_bookmarks_translate_errors(ret, errlist, bookmarks):
 def lzc_snaprange_space_translate_error(ret, firstsnap, lastsnap):
     if ret == 0:
         return
+    if ret == errno.EXDEV and firstsnap is not None:
+        if _pool_name(firstsnap) != _pool_name(lastsnap):
+            raise lzc_exc.PoolsDiffer(lastsnap)
+        else:
+            raise lzc_exc.SnapshotMismatch(lastsnap)
     if ret == errno.EINVAL:
         if not _is_valid_snap_name(firstsnap):
             raise lzc_exc.NameInvalid(firstsnap)

--- a/libzfs_core/test/test_libzfs_core.py
+++ b/libzfs_core/test/test_libzfs_core.py
@@ -1267,7 +1267,7 @@ class ZFSTest(unittest.TestCase):
 
     def test_snaprange_space_nonexistent(self):
         snap1 = ZFSTest.pool.makeName("fs1@snap1")
-        snap2 = ZFSTest.pool.makeName("fs2@snap2")
+        snap2 = ZFSTest.pool.makeName("fs1@snap2")
 
         lzc.lzc_snapshot([snap1])
 


### PR DESCRIPTION
It seems that the change has been introduced in libzfs_core-wip
branch and the wrapper has to catch up with it.
