### PR TITLE
lzc_list_snaps can be misused / abused on a snapshot

### DIFF
--- a/libzfs_core/_libzfs_core.py
+++ b/libzfs_core/_libzfs_core.py
@@ -1081,9 +1081,10 @@ def lzc_list_snaps(name):
     snaps = []
     for entry in _list(name, recurse=1, types=['snapshot']):
         # XXX we shouldn't need to do this, but have to work around ZFS-26
+        snap = entry['name']
         is_snapshot = entry['dmu_objset_stats']['dds_is_snapshot']
-        if is_snapshot:
-            snaps.append(entry['name'])
+        if is_snapshot and snap != name:
+            snaps.append(snap)
 
     return iter(snaps)
 


### PR DESCRIPTION
That situation could be considered as an error, but it is not now.
It's documented that in that case an empty listing is produced.
But lzc_list() would produce a list that includes the snapshot
itself, so we have to ignore it similarly to what is done in
lzc_list_children (but for different reasons).
