### PR TITLE
add lzc_receive_with_header() and a helper function receive_header()

### DIFF
--- a/libzfs_core/__init__.py
+++ b/libzfs_core/__init__.py
@@ -45,6 +45,7 @@ from ._libzfs_core import (
     lzc_send,
     lzc_send_space,
     lzc_receive,
+    lzc_receive_with_header,
     lzc_recv,
     lzc_exists,
     is_supported,
@@ -56,6 +57,7 @@ from ._libzfs_core import (
     lzc_get_props,
     lzc_list_children,
     lzc_list_snaps,
+    receive_header,
 )
 
 __all__ = [
@@ -78,6 +80,7 @@ __all__ = [
     'lzc_send',
     'lzc_send_space',
     'lzc_receive',
+    'lzc_receive_with_header',
     'lzc_recv',
     'lzc_exists',
     'is_supported',
@@ -89,6 +92,7 @@ __all__ = [
     'lzc_get_props',
     'lzc_list_children',
     'lzc_list_snaps',
+    'receive_header',
 ]
 
 # vim: softtabstop=4 tabstop=4 expandtab shiftwidth=4

--- a/libzfs_core/_libzfs_core.py
+++ b/libzfs_core/_libzfs_core.py
@@ -722,7 +722,7 @@ def lzc_receive_with_header(snapname, fd, header, force=False, origin=None, prop
         props = {}
     nvlist = nvlist_in(props)
     ret = _lib.lzc_receive_with_header(snapname, nvlist, c_origin, force,
-                                       False, fd, _ffi.addressof(header))
+                                       False, fd, header)
     errors.lzc_receive_translate_error(ret, snapname, fd, force, origin, props)
 
 
@@ -757,18 +757,18 @@ def receive_header(fd):
     record = _ffi.new("dmu_replay_record_t *")
     _ffi.buffer(record)[:] = os.read(fd, _ffi.sizeof(record[0]))
     # get drr_begin member and its representation as a Pythn dict
-    c_header = record.drr_u.drr_begin
+    drr_begin = record.drr_u.drr_begin
     header = {}
-    for field, descr in _ffi.typeof(c_header).fields:
+    for field, descr in _ffi.typeof(drr_begin).fields:
         if descr.type.kind == 'primitive':
-            header[field] = getattr(c_header, field)
+            header[field] = getattr(drr_begin, field)
         elif descr.type.kind == 'enum':
-            header[field] = getattr(c_header, field)
+            header[field] = getattr(drr_begin, field)
         elif descr.type.kind == 'array' and descr.type.item.cname == 'char':
-            header[field] = _ffi.string(getattr(c_header, field))
+            header[field] = _ffi.string(getattr(drr_begin, field))
         else:
             raise TypeError('Unexpected field type in drr_begin: ' + str(descr.type))
-    return (header, c_header)
+    return (header, record)
 
 
 def lzc_exists(name):

--- a/libzfs_core/bindings/libzfs_core.py
+++ b/libzfs_core/bindings/libzfs_core.py
@@ -75,7 +75,7 @@ CDEF = """
     int lzc_send_space(const char *, const char *, uint64_t *);
     int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, int);
     int lzc_receive_with_header(const char *, nvlist_t *, const char *, boolean_t,
-        boolean_t, int, const struct drr_begin *);
+        boolean_t, int, const struct dmu_replay_record *);
 
     boolean_t lzc_exists(const char *);
 


### PR DESCRIPTION
Using these functions will allow to examine the stream metadata that is
included into the stream begin record.  In particular, we will be able
to see the snapshot name used on the sending side, so that we can use
the same snapshot name on the receiving side.

See:
- https://clusterhq.atlassian.net/browse/ZFS-20
- https://reviews.csiden.org/r/256/
- https://www.illumos.org/issues/6051
