### PR TITLE
lzc_get_props acts only on the specified dataset, so no recursion

### DIFF
--- a/libzfs_core/_libzfs_core.py
+++ b/libzfs_core/_libzfs_core.py
@@ -927,18 +927,23 @@ def _list(name, recurse=None, types=None):
     :param recurse: specifies depth of the recursive listing.
                     If ``None`` the depth is not limited.
     :param types: specifies dataset types to include into the listing.
-                  Currently allowed keys are "filesystem", "volume", "snapshot".
-                  None or an empty list means all dataset types.
+        Currently allowed keys are "filesystem", "volume", "snapshot".
+        ``None`` is equivalent to specifying the type of the dataset
+        named by `name`.
     :type types: list of bytes or None
     :type recurse: integer or None
     :return: a list of dictionaries each describing a single listed
              element.
     :rtype: list of dict
     '''
+    options = {}
+
     # Convert types to a dict suitable for mapping to an nvlist.
     if types is not None:
         types = {x: None for x in types}
-    options = {'recurse': recurse, 'type': types}
+        options['type'] = types
+    if recurse is None or recurse > 0:
+        options['recurse'] = recurse
 
     # Note that other_fd is used by the kernel side to write
     # the data, so we have to keep that descriptor open until
@@ -995,7 +1000,7 @@ def lzc_get_props(name):
         with default values.  One exception is the ``mountpoint`` property
         for which the default value is derived from the dataset name.
     '''
-    result = next(_list(name))
+    result = next(_list(name, recurse=0))
     is_snapshot = result['dmu_objset_stats']['dds_is_snapshot']
     result = result['properties']
     # In most cases the source of the property is uninteresting and the

--- a/libzfs_core/test/test_libzfs_core.py
+++ b/libzfs_core/test/test_libzfs_core.py
@@ -3106,6 +3106,20 @@ class ZFSTest(unittest.TestCase):
         self.assertDictContainsSubset(props, actual_props)
 
     @needs_support(lzc.lzc_get_props)
+    def test_get_fs_props_with_child(self):
+        parent = ZFSTest.pool.makeName("parent")
+        child = ZFSTest.pool.makeName("parent/child")
+        parent_props = {"user:foo": "parent"}
+        child_props = {"user:foo": "child"}
+
+        lzc.lzc_create(parent, props=parent_props)
+        lzc.lzc_create(child, props=child_props)
+        actual_parent_props = lzc.lzc_get_props(parent)
+        actual_child_props = lzc.lzc_get_props(child)
+        self.assertDictContainsSubset(parent_props, actual_parent_props)
+        self.assertDictContainsSubset(child_props, actual_child_props)
+
+    @needs_support(lzc.lzc_get_props)
     def test_get_snap_props(self):
         snapname = ZFSTest.pool.makeName("@snap")
         snaps = [snapname]


### PR DESCRIPTION
This should fix issue #27.

Previously, lzc_get_props did not set 'recursion' argument
for _list() which resulted in the unlimited recursion and thus
we get properties of a child dataset instead of the requested one.

While there fix a problem where we passed 'type' as a boolean nvlist
element.  The kernel treated it the same as a missing element because
of the unexpected type, but that was fragile and confusing.
So, now we do not set 'type' element at all if no type is explicitly
requested.

Also, if 'recurse' parameter is set to zero, then we do not set
'recurse' element at all, which is a more natural indicator that
no recursion is asked for.

Finally, a test case is added to check for the fixed problem.
