### PR TITLE
[PoC] add support for Python 3

### DIFF
--- a/libzfs_core/__init__.py
+++ b/libzfs_core/__init__.py
@@ -23,6 +23,7 @@ please visit its `GitHub repository <https://github.com/ClusterHQ/pyzfs>`_.
 
     Maximum length of any ZFS name.
 '''
+from __future__ import unicode_literals
 
 from ._constants import (
     MAXNAMELEN,

--- a/libzfs_core/_constants.py
+++ b/libzfs_core/_constants.py
@@ -3,6 +3,7 @@
 """
 Important `libzfs_core` constants.
 """
+from __future__ import unicode_literals
 
 #: Maximum length of any ZFS name.
 MAXNAMELEN = 255

--- a/libzfs_core/_error_translation.py
+++ b/libzfs_core/_error_translation.py
@@ -12,7 +12,9 @@ corresponding interface functions.
 
 The parameters and exceptions are documented in the `libzfs_core` interfaces.
 """
+from __future__ import unicode_literals
 
+from builtins import map
 import errno
 import re
 import string
@@ -74,7 +76,7 @@ def lzc_snapshot_translate_errors(ret, errlist, snaps, props):
 
     def _map(ret, name):
         if ret == errno.EXDEV:
-            pool_names = map(_pool_name, snaps)
+            pool_names = list(map(_pool_name, snaps))
             same_pool = all(x == pool_names[0] for x in pool_names)
             if same_pool:
                 return lzc_exc.DuplicateSnapshots(name)
@@ -121,7 +123,7 @@ def lzc_bookmark_translate_errors(ret, errlist, bookmarks):
         if ret == errno.EINVAL:
             if name:
                 snap = bookmarks[name]
-                pool_names = map(_pool_name, bookmarks.keys())
+                pool_names = list(map(_pool_name, list(bookmarks.keys())))
                 if not _is_valid_bmark_name(name):
                     return lzc_exc.BookmarkNameInvalid(name)
                 elif not _is_valid_snap_name(snap):
@@ -131,7 +133,7 @@ def lzc_bookmark_translate_errors(ret, errlist, bookmarks):
                 elif any(x != _pool_name(name) for x in pool_names):
                     return lzc_exc.PoolsDiffer(name)
             else:
-                invalid_names = [b for b in bookmarks.keys() if not _is_valid_bmark_name(b)]
+                invalid_names = [b for b in list(bookmarks.keys()) if not _is_valid_bmark_name(b)]
                 if invalid_names:
                     return lzc_exc.BookmarkNameInvalid(invalid_names[0])
         if ret == errno.EEXIST:
@@ -142,7 +144,7 @@ def lzc_bookmark_translate_errors(ret, errlist, bookmarks):
             return lzc_exc.BookmarkNotSupported(name)
         return _generic_exception(ret, name, "Failed to create bookmark")
 
-    _handle_err_list(ret, errlist, bookmarks.keys(), lzc_exc.BookmarkFailure, _map)
+    _handle_err_list(ret, errlist, list(bookmarks.keys()), lzc_exc.BookmarkFailure, _map)
 
 
 def lzc_get_bookmarks_translate_error(ret, fsname, props):
@@ -200,7 +202,7 @@ def lzc_hold_translate_errors(ret, errlist, holds, fd):
             return lzc_exc.PoolsDiffer(name)
         elif ret == errno.EINVAL:
             if name:
-                pool_names = map(_pool_name, holds.keys())
+                pool_names = list(map(_pool_name, list(holds.keys())))
                 if not _is_valid_snap_name(name):
                     return lzc_exc.NameInvalid(name)
                 elif len(name) > MAXNAMELEN:
@@ -208,7 +210,7 @@ def lzc_hold_translate_errors(ret, errlist, holds, fd):
                 elif any(x != _pool_name(name) for x in pool_names):
                     return lzc_exc.PoolsDiffer(name)
             else:
-                invalid_names = [b for b in holds.keys() if not _is_valid_snap_name(b)]
+                invalid_names = [b for b in list(holds.keys()) if not _is_valid_snap_name(b)]
                 if invalid_names:
                     return lzc_exc.NameInvalid(invalid_names[0])
         fs_name = None
@@ -230,13 +232,13 @@ def lzc_hold_translate_errors(ret, errlist, holds, fd):
 
     if ret == errno.EBADF:
         raise lzc_exc.BadHoldCleanupFD()
-    _handle_err_list(ret, errlist, holds.keys(), lzc_exc.HoldFailure, _map)
+    _handle_err_list(ret, errlist, list(holds.keys()), lzc_exc.HoldFailure, _map)
 
 
 def lzc_release_translate_errors(ret, errlist, holds):
     if ret == 0:
         return
-    for _, hold_list in holds.iteritems():
+    for _, hold_list in holds.items():
         if not isinstance(hold_list, list):
             raise lzc_exc.TypeError('holds must be in a list')
 
@@ -245,7 +247,7 @@ def lzc_release_translate_errors(ret, errlist, holds):
             return lzc_exc.PoolsDiffer(name)
         elif ret == errno.EINVAL:
             if name:
-                pool_names = map(_pool_name, holds.keys())
+                pool_names = list(map(_pool_name, list(holds.keys())))
                 if not _is_valid_snap_name(name):
                     return lzc_exc.NameInvalid(name)
                 elif len(name) > MAXNAMELEN:
@@ -253,7 +255,7 @@ def lzc_release_translate_errors(ret, errlist, holds):
                 elif any(x != _pool_name(name) for x in pool_names):
                     return lzc_exc.PoolsDiffer(name)
             else:
-                invalid_names = [b for b in holds.keys() if not _is_valid_snap_name(b)]
+                invalid_names = [b for b in list(holds.keys()) if not _is_valid_snap_name(b)]
                 if invalid_names:
                     return lzc_exc.NameInvalid(invalid_names[0])
         elif ret == errno.ENOENT:
@@ -270,7 +272,7 @@ def lzc_release_translate_errors(ret, errlist, holds):
         else:
             return _generic_exception(ret, name, "Failed to release snapshot hold")
 
-    _handle_err_list(ret, errlist, holds.keys(), lzc_exc.HoldReleaseFailure, _map)
+    _handle_err_list(ret, errlist, list(holds.keys()), lzc_exc.HoldReleaseFailure, _map)
 
 
 def lzc_get_holds_translate_error(ret, snapname):
@@ -525,7 +527,7 @@ def _handle_err_list(ret, errlist, names, exception, mapper):
     else:
         errors = []
         suppressed_count = errlist.pop('N_MORE_ERRORS', 0)
-        for name, err in errlist.iteritems():
+        for name, err in errlist.items():
             errors.append(mapper(err, name))
 
     raise exception(errors, suppressed_count)

--- a/libzfs_core/_libzfs_core.py
+++ b/libzfs_core/_libzfs_core.py
@@ -12,7 +12,10 @@ increased convenience.  Output parameters are not used and return values
 are directly returned.  Error conditions are signalled by exceptions
 rather than by integer error codes.
 """
+from __future__ import unicode_literals
 
+from builtins import next
+from builtins import object
 import errno
 import functools
 import fcntl
@@ -376,8 +379,8 @@ def lzc_hold(holds, fd=None):
     errors.lzc_hold_translate_errors(ret, errlist, holds, fd)
     # If there is no error (no exception raised by _handleErrList), but errlist
     # is not empty, then it contains missing snapshots.
-    assert all(x == errno.ENOENT for x in errlist.itervalues())
-    return errlist.keys()
+    assert all(x == errno.ENOENT for x in errlist.values())
+    return list(errlist.keys())
 
 
 def lzc_release(holds):
@@ -411,7 +414,7 @@ def lzc_release(holds):
     '''
     errlist = {}
     holds_dict = {}
-    for snap, hold_list in holds.iteritems():
+    for snap, hold_list in holds.items():
         if not isinstance(hold_list, list):
             raise TypeError('holds must be in a list')
         holds_dict[snap] = {hold: None for hold in hold_list}
@@ -421,8 +424,8 @@ def lzc_release(holds):
     errors.lzc_release_translate_errors(ret, errlist, holds)
     # If there is no error (no exception raised by _handleErrList), but errlist
     # is not empty, then it contains missing snapshots and tags.
-    assert all(x == errno.ENOENT for x in errlist.itervalues())
-    return errlist.keys()
+    assert all(x == errno.ENOENT for x in errlist.values())
+    return list(errlist.keys())
 
 
 def lzc_get_holds(snapname):
@@ -1025,9 +1028,9 @@ def lzc_get_props(name):
         mountpoint_val = '/' + name
     else:
         mountpoint_val = None
-    result = {k: v['value'] for k, v in result.iteritems()}
+    result = {k: v['value'] for k, v in result.items()}
     if 'clones' in result:
-        result['clones'] = result['clones'].keys()
+        result['clones'] = list(result['clones'].keys())
     if mountpoint_val is not None:
         result['mountpoint'] = mountpoint_val
     return result

--- a/libzfs_core/_libzfs_core.py
+++ b/libzfs_core/_libzfs_core.py
@@ -754,8 +754,8 @@ def lzc_rename(source, target):
     '''
     Rename the ZFS dataset.
 
-    :param source name: the current name of the dataset to rename.
-    :param target name: the new name of the dataset.
+    :param bytes source: the current name of the dataset to rename.
+    :param bytes target: the new name of the dataset.
     :raises NameInvalid: if either the source or target name is invalid.
     :raises NameTooLong: if either the source or target name is too long.
     :raises NameTooLong: if a snapshot of the source would get a too long

--- a/libzfs_core/_nvlist.py
+++ b/libzfs_core/_nvlist.py
@@ -30,7 +30,9 @@ Format:
 - a value can be a list of dictionaries that adhere to this format
 - all elements of a list value must be of the same type
 """
+from __future__ import unicode_literals
 
+from builtins import range
 import numbers
 from collections import namedtuple
 from contextlib import contextmanager
@@ -228,7 +230,7 @@ def _nvlist_to_dict(nvlist, props):
 
 
 def _dict_to_nvlist(props, nvlist):
-    for k, v in props.items():
+    for k, v in list(props.items()):
         if not isinstance(k, bytes):
             raise TypeError('Unsupported key type ' + type(k).__name__)
         ret = 0

--- a/libzfs_core/bindings/__init__.py
+++ b/libzfs_core/bindings/__init__.py
@@ -5,7 +5,9 @@ The package that contains a module per each C library that
 `libzfs_core` uses.  The modules expose CFFI objects required
 to make calls to functions in the libraries.
 """
+from __future__ import unicode_literals
 
+from builtins import object
 import threading
 import importlib
 

--- a/libzfs_core/bindings/libnvpair.py
+++ b/libzfs_core/bindings/libnvpair.py
@@ -3,6 +3,7 @@
 """
 Python bindings for ``libnvpair``.
 """
+from __future__ import unicode_literals
 
 CDEF = """
     typedef ... nvlist_t;

--- a/libzfs_core/bindings/libzfs_core.py
+++ b/libzfs_core/bindings/libzfs_core.py
@@ -3,6 +3,7 @@
 """
 Python bindings for ``libzfs_core``.
 """
+from __future__ import unicode_literals
 
 CDEF = """
     enum lzc_send_flags {

--- a/libzfs_core/ctypes.py
+++ b/libzfs_core/ctypes.py
@@ -22,7 +22,7 @@ def _ffi_cast(type_name):
         else:
             _ffi.new(type_name + '*', value)
         return _ffi.cast(type_name, value)
-    _func.__name__ = type_name
+    _func.__name__ = type_name.encode()
     return _func
 
 

--- a/libzfs_core/ctypes.py
+++ b/libzfs_core/ctypes.py
@@ -3,7 +3,6 @@
 """
 Utility functions for casting to a specific C type.
 """
-from __future__ import unicode_literals
 
 from .bindings.libnvpair import ffi as _ffi
 
@@ -22,7 +21,7 @@ def _ffi_cast(type_name):
         else:
             _ffi.new(type_name + '*', value)
         return _ffi.cast(type_name, value)
-    _func.__name__ = type_name.encode()
+    _func.__name__ = type_name
     return _func
 
 

--- a/libzfs_core/ctypes.py
+++ b/libzfs_core/ctypes.py
@@ -3,6 +3,7 @@
 """
 Utility functions for casting to a specific C type.
 """
+from __future__ import unicode_literals
 
 from .bindings.libnvpair import ffi as _ffi
 

--- a/libzfs_core/exceptions.py
+++ b/libzfs_core/exceptions.py
@@ -3,6 +3,7 @@
 """
 Exceptions that can be raised by libzfs_core operations.
 """
+from __future__ import unicode_literals
 
 import errno
 

--- a/libzfs_core/test/__init__.py
+++ b/libzfs_core/test/__init__.py
@@ -1,0 +1,43 @@
+"""
+The package that contains a module for unit testing.
+"""
+
+from __future__ import unicode_literals
+
+from builtins import str
+
+
+def _bytes(obj):
+    """
+    Convert str in complex object to bytes.
+
+    :param object obj: the object includes str.
+    :return: return a new object includes converted bytes objects.
+    :rtype: object
+    """
+
+    def _b(s):
+        if isinstance(s, str):
+            return s.encode()
+        else:
+            return s
+
+    if isinstance(obj, dict):
+        t = {}
+        for k, v in obj.items():
+            if isinstance(k, str):
+                k = _b(k)
+            t[k] = _bytes(v)
+        return t
+
+    elif isinstance(obj, list):
+        t = []
+        for e in obj:
+            t.append(_bytes(e))
+        return t
+
+    elif isinstance(obj, str):
+        return _b(obj)
+
+    else:
+        return obj

--- a/libzfs_core/test/test_libzfs_core.py
+++ b/libzfs_core/test/test_libzfs_core.py
@@ -7,6 +7,7 @@ These are mostly functional and conformance tests that validate
 that the operations produce expected effects or fail with expected
 exceptions.
 """
+from __future__ import print_function
 
 import unittest
 import contextlib
@@ -27,8 +28,8 @@ from .. import exceptions as lzc_exc
 
 def _print(*args):
     for arg in args:
-        print arg,
-    print
+        print(arg, end=' ')
+    print()
 
 
 @contextlib.contextmanager
@@ -59,7 +60,7 @@ def _zfs_mount(fs):
             with suppress():
                 subprocess.check_output(unmount_cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        print 'failed to mount %s @ %s : %s' % (fs, mntdir, e.output)
+        print('failed to mount %s @ %s : %s' % (fs, mntdir, e.output))
         raise
     finally:
         os.rmdir(mntdir)
@@ -3483,7 +3484,7 @@ class _TempPool(object):
             if 'permission denied' in e.output:
                 raise unittest.SkipTest(
                     'insufficient privileges to run libzfs_core tests')
-            print 'command failed: ', e.output
+            print('command failed: ', e.output)
             raise
         except Exception:
             self.cleanUp()
@@ -3518,7 +3519,7 @@ class _TempPool(object):
             subprocess.check_output(
                 self._zpool_create, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print 'command failed: ', e.output
+            print('command failed: ', e.output)
             raise
         for fs in self._filesystems:
             lzc.lzc_create(self.makeName(fs))

--- a/libzfs_core/test/test_libzfs_core.py
+++ b/libzfs_core/test/test_libzfs_core.py
@@ -31,6 +31,7 @@ from builtins import str
 from builtins import zip
 from past.utils import old_div
 
+from . import _bytes
 from .. import _libzfs_core as lzc
 from .. import exceptions as lzc_exc
 
@@ -160,7 +161,7 @@ def temp_file_in_fs(fs):
     with zfs_mount(fs) as mntdir:
         with tempfile.NamedTemporaryFile(dir=mntdir) as f:
             for i in range(1024):
-                f.write('x' * 1024)
+                f.write(_bytes('x' * 1024))
             f.flush()
             yield f.name
 
@@ -888,7 +889,7 @@ class ZFSTest(unittest.TestCase):
 
         lzc.lzc_snapshot([snapname])
         ret = lzc.lzc_rollback(name)
-        self.assertEqual(ret, snapname)
+        self.assertEqual(ret, _bytes(snapname))
 
     def test_rollback_2(self):
         name = ZFSTest.pool.makeName("fs1")
@@ -898,7 +899,7 @@ class ZFSTest(unittest.TestCase):
         lzc.lzc_snapshot([snapname1])
         lzc.lzc_snapshot([snapname2])
         ret = lzc.lzc_rollback(name)
-        self.assertEqual(ret, snapname2)
+        self.assertEqual(ret, _bytes(snapname2))
 
     def test_rollback_no_snaps(self):
         name = ZFSTest.pool.makeName("fs1")
@@ -1262,7 +1263,7 @@ class ZFSTest(unittest.TestCase):
         with zfs_mount(ZFSTest.pool.makeName("fs1")) as mntdir:
             with tempfile.NamedTemporaryFile(dir=mntdir) as f:
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 f.flush()
                 lzc.lzc_snapshot([snap2])
         lzc.lzc_snapshot([snap3])
@@ -1280,7 +1281,7 @@ class ZFSTest(unittest.TestCase):
         with zfs_mount(ZFSTest.pool.makeName("fs1")) as mntdir:
             with tempfile.NamedTemporaryFile(dir=mntdir) as f:
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 f.flush()
                 lzc.lzc_snapshot([snap])
 
@@ -1394,7 +1395,7 @@ class ZFSTest(unittest.TestCase):
         with zfs_mount(ZFSTest.pool.makeName("fs1")) as mntdir:
             with tempfile.NamedTemporaryFile(dir=mntdir) as f:
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 f.flush()
                 lzc.lzc_snapshot([snap2])
         lzc.lzc_snapshot([snap3])
@@ -1514,7 +1515,7 @@ class ZFSTest(unittest.TestCase):
         with zfs_mount(ZFSTest.pool.makeName("fs1")) as mntdir:
             with tempfile.NamedTemporaryFile(dir=mntdir) as f:
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 f.flush()
                 lzc.lzc_snapshot([snap])
 
@@ -1535,7 +1536,7 @@ class ZFSTest(unittest.TestCase):
         with zfs_mount(ZFSTest.pool.makeName("fs1")) as mntdir:
             with tempfile.NamedTemporaryFile(dir=mntdir) as f:
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 f.flush()
                 lzc.lzc_snapshot([snap2])
 
@@ -1751,7 +1752,7 @@ class ZFSTest(unittest.TestCase):
         with zfs_mount(ZFSTest.pool.makeName("fs1")) as mntdir:
             with tempfile.NamedTemporaryFile(dir=mntdir) as f:
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 f.flush()
                 lzc.lzc_snapshot([snap])
 
@@ -2253,7 +2254,7 @@ class ZFSTest(unittest.TestCase):
             with zfs_mount(dstfs) as mntdir:
                 f = tempfile.NamedTemporaryFile(dir=mntdir, delete=False)
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 lzc.lzc_receive(dst, stream.fileno(), force=True)
                 # The temporary file dissappears and any access, even close(),
                 # results in EIO.
@@ -2340,7 +2341,7 @@ class ZFSTest(unittest.TestCase):
             with zfs_mount(dstfs) as mntdir:
                 f = tempfile.NamedTemporaryFile(dir=mntdir, delete=False)
                 for i in range(1024):
-                    f.write('x' * 1024)
+                    f.write(_bytes('x' * 1024))
                 lzc.lzc_receive(dst2, incr.fileno(), force=True)
                 # The temporary file dissappears and any access, even close(),
                 # results in EIO.
@@ -2708,7 +2709,7 @@ class ZFSTest(unittest.TestCase):
         with cleanup_fd() as fd:
             missing = lzc.lzc_hold({snap1: 'tag', snap2: 'tag'}, fd)
         self.assertEqual(len(missing), 1)
-        self.assertEqual(missing[0], snap2)
+        self.assertEqual(missing[0], _bytes(snap2))
 
     def test_hold_many_with_all_missing(self):
         snap1 = ZFSTest.pool.getRoot().getSnap()
@@ -2717,7 +2718,7 @@ class ZFSTest(unittest.TestCase):
         with cleanup_fd() as fd:
             missing = lzc.lzc_hold({snap1: 'tag', snap2: 'tag'}, fd)
         self.assertEqual(len(missing), 2)
-        self.assertEqual(sorted(missing), sorted([snap1, snap2]))
+        self.assertEqual(sorted(missing), sorted(_bytes([snap1, snap2])))
 
     def test_hold_missing_fs(self):
         # XXX skip pre-created filesystems
@@ -2832,8 +2833,8 @@ class ZFSTest(unittest.TestCase):
 
             holds = lzc.lzc_get_holds(snap)
             self.assertEquals(len(holds), 2)
-            self.assertIn('tag1', holds)
-            self.assertIn('tag2', holds)
+            self.assertIn(_bytes('tag1'), holds)
+            self.assertIn(_bytes('tag2'), holds)
             self.assertIsInstance(holds['tag1'], (int, int))
 
     def test_get_holds_after_auto_cleanup(self):
@@ -2976,21 +2977,21 @@ class ZFSTest(unittest.TestCase):
 
         ret = lzc.lzc_release({snap: ['tag']})
         self.assertEquals(len(ret), 1)
-        self.assertEquals(ret[0], snap + '#tag')
+        self.assertEquals(ret[0], _bytes(snap + '#tag'))
 
     def test_release_hold_missing_snap(self):
         snap = ZFSTest.pool.getRoot().getSnap()
 
         ret = lzc.lzc_release({snap: ['tag']})
         self.assertEquals(len(ret), 1)
-        self.assertEquals(ret[0], snap)
+        self.assertEquals(ret[0], _bytes(snap))
 
     def test_release_hold_missing_snap_2(self):
         snap = ZFSTest.pool.getRoot().getSnap()
 
         ret = lzc.lzc_release({snap: ['tag', 'another']})
         self.assertEquals(len(ret), 1)
-        self.assertEquals(ret[0], snap)
+        self.assertEquals(ret[0], _bytes(snap))
 
     def test_release_hold_across_pools(self):
         snap1 = ZFSTest.pool.getRoot().getSnap()
@@ -3032,7 +3033,7 @@ class ZFSTest(unittest.TestCase):
             lzc.lzc_release({snap: ['tag']})
         for e in ctx.exception.errors:
             self.assertIsInstance(e, lzc_exc.NameTooLong)
-            self.assertEquals(e.name, snap)
+            self.assertEquals(e.name, _bytes(snap))
 
     def test_release_hold_invalid_snap_name(self):
         snap = ZFSTest.pool.getRoot().getSnap() + '@bad'

--- a/libzfs_core/test/test_libzfs_core.py
+++ b/libzfs_core/test/test_libzfs_core.py
@@ -8,7 +8,14 @@ that the operations produce expected effects or fail with expected
 exceptions.
 """
 from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import bytes
+from builtins import zip
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import unittest
 import contextlib
 import errno
@@ -1238,11 +1245,11 @@ class ZFSTest(unittest.TestCase):
         lzc.lzc_snapshot([snap3])
 
         space = lzc.lzc_snaprange_space(snap1, snap2)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
         space = lzc.lzc_snaprange_space(snap2, snap3)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
         space = lzc.lzc_snaprange_space(snap1, snap3)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
 
     def test_snaprange_space_2(self):
         snap1 = ZFSTest.pool.makeName("fs1@snap1")
@@ -1364,17 +1371,17 @@ class ZFSTest(unittest.TestCase):
         lzc.lzc_snapshot([snap3])
 
         space = lzc.lzc_send_space(snap2, snap1)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
         space = lzc.lzc_send_space(snap3, snap2)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
         space = lzc.lzc_send_space(snap3, snap1)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
         space = lzc.lzc_send_space(snap1)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
         space = lzc.lzc_send_space(snap2)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
         space = lzc.lzc_send_space(snap3)
-        self.assertIsInstance(space, (int, long))
+        self.assertIsInstance(space, (int, int))
 
     def test_send_space_2(self):
         snap1 = ZFSTest.pool.makeName("fs1@snap1")
@@ -1516,7 +1523,7 @@ class ZFSTest(unittest.TestCase):
             lzc.lzc_send(snap, None, fd)
             st = os.fstat(fd)
             # 5%, arbitrary.
-            self.assertAlmostEqual(st.st_size, estimate, delta=estimate / 20)
+            self.assertAlmostEqual(st.st_size, estimate, delta=old_div(estimate, 20))
 
     def test_send_incremental(self):
         snap1 = ZFSTest.pool.makeName("fs1@snap1")
@@ -1537,7 +1544,7 @@ class ZFSTest(unittest.TestCase):
             lzc.lzc_send(snap2, snap1, fd)
             st = os.fstat(fd)
             # 5%, arbitrary.
-            self.assertAlmostEqual(st.st_size, estimate, delta=estimate / 20)
+            self.assertAlmostEqual(st.st_size, estimate, delta=old_div(estimate, 20))
 
     def test_send_flags(self):
         snap = ZFSTest.pool.makeName("fs1@snap")
@@ -2825,7 +2832,7 @@ class ZFSTest(unittest.TestCase):
             self.assertEquals(len(holds), 2)
             self.assertIn('tag1', holds)
             self.assertIn('tag2', holds)
-            self.assertIsInstance(holds['tag1'], (int, long))
+            self.assertIsInstance(holds['tag1'], (int, int))
 
     def test_get_holds_after_auto_cleanup(self):
         snap = ZFSTest.pool.getRoot().getSnap()

--- a/libzfs_core/test/test_libzfs_core.py
+++ b/libzfs_core/test/test_libzfs_core.py
@@ -7,16 +7,10 @@ These are mostly functional and conformance tests that validate
 that the operations produce expected effects or fail with expected
 exceptions.
 """
-from __future__ import print_function
 from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 
-from builtins import bytes
-from builtins import zip
-from builtins import range
-from builtins import object
-from past.utils import old_div
-import unittest
 import contextlib
 import errno
 import filecmp
@@ -28,7 +22,15 @@ import stat
 import subprocess
 import tempfile
 import time
+import unittest
 import uuid
+
+from builtins import object
+from builtins import range
+from builtins import str
+from builtins import zip
+from past.utils import old_div
+
 from .. import _libzfs_core as lzc
 from .. import exceptions as lzc_exc
 
@@ -3451,7 +3453,7 @@ class _TempPool(object):
     def __init__(self, size=128 * 1024 * 1024, readonly=False, filesystems=[]):
         self._filesystems = filesystems
         self._readonly = readonly
-        self._pool_name = 'pool.' + bytes(uuid.uuid4())
+        self._pool_name = 'pool.' + str(uuid.uuid4())
         self._root = _Filesystem(self._pool_name)
         (fd, self._pool_file_path) = tempfile.mkstemp(
             suffix='.zpool', prefix='tmp-')
@@ -3610,20 +3612,20 @@ class _Filesystem(object):
 
     def getFilesystem(self):
         self._fs_id += 1
-        fsname = self._name + '/fs' + bytes(self._fs_id)
+        fsname = self._name + '/fs' + str(self._fs_id)
         fs = _Filesystem(fsname)
         self._children.append(fs)
         return fs
 
     def _makeSnapName(self, i):
-        return self._name + '@snap' + bytes(i)
+        return self._name + '@snap' + str(i)
 
     def getSnap(self):
         self._snap_id += 1
         return self._makeSnapName(self._snap_id)
 
     def _makeBookmarkName(self, i):
-        return self._name + '#bmark' + bytes(i)
+        return self._name + '#bmark' + str(i)
 
     def getBookmark(self):
         self._bmark_id += 1

--- a/libzfs_core/test/test_nvlist.py
+++ b/libzfs_core/test/test_nvlist.py
@@ -9,9 +9,11 @@ value types or out of bounds values are detected.
 """
 from __future__ import unicode_literals
 
-from builtins import zip
 import unittest
 
+from builtins import zip
+
+from . import _bytes
 from .._nvlist import nvlist_in, nvlist_out, _lib
 from ..ctypes import (
     uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,
@@ -69,17 +71,17 @@ class TestNVList(unittest.TestCase):
     def test_string_value(self):
         props = {"key": "value"}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_implicit_boolean_value(self):
         props = {"key": None}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_boolean_values(self):
         props = {"key1": True, "key2": False}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_explicit_boolean_true_value(self):
         props = {"key": boolean_t(1)}
@@ -104,12 +106,12 @@ class TestNVList(unittest.TestCase):
     def test_uint64_value(self):
         props = {"key": 1}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_uint64_max_value(self):
         props = {"key": 2 ** 64 - 1}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_uint64_too_large_value(self):
         props = {"key": 2 ** 64}
@@ -324,12 +326,12 @@ class TestNVList(unittest.TestCase):
     def test_nested_dict(self):
         props = {"key": {}}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_nested_nested_dict(self):
         props = {"key": {"key": {}}}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_mismatching_values_array(self):
         props = {"key": [1, "string"]}
@@ -349,12 +351,12 @@ class TestNVList(unittest.TestCase):
     def test_string_array(self):
         props = {"key": ["value", "value2"]}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_boolean_array(self):
         props = {"key": [True, False]}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_explicit_boolean_array(self):
         props = {"key": [boolean_t(False), boolean_t(True)]}
@@ -364,7 +366,7 @@ class TestNVList(unittest.TestCase):
     def test_uint64_array(self):
         props = {"key": [0, 1, 2 ** 64 - 1]}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_uint64_array_too_large_value(self):
         props = {"key": [0, 2 ** 64]}
@@ -519,7 +521,7 @@ class TestNVList(unittest.TestCase):
     def test_dict_array(self):
         props = {"key": [{"key": 1}, {"key": None}, {"key": {}}]}
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
     def test_implicit_uint32_value(self):
         props = {"rewind-request": 1}
@@ -608,7 +610,7 @@ class TestNVList(unittest.TestCase):
             "pool_context": -(2 ** 31)
         }
         res = self._dict_to_nvlist_to_dict(props)
-        self.assertEqual(props, res)
+        self.assertEqual(_bytes(props), res)
 
 
 # vim: softtabstop=4 tabstop=4 expandtab shiftwidth=4

--- a/libzfs_core/test/test_nvlist.py
+++ b/libzfs_core/test/test_nvlist.py
@@ -7,7 +7,9 @@ and verify that no information is lost and value types are correct.
 The tests also check that various error conditions like unsupported
 value types or out of bounds values are detected.
 """
+from __future__ import unicode_literals
 
+from builtins import zip
 import unittest
 
 from .._nvlist import nvlist_in, nvlist_out, _lib
@@ -28,12 +30,12 @@ class TestNVList(unittest.TestCase):
 
     def _assertIntDictsEqual(self, dict1, dict2):
         self.assertEqual(len(dict1), len(dict1), "resulting dictionary is of different size")
-        for key in dict1.keys():
+        for key in list(dict1.keys()):
             self.assertEqual(int(dict1[key]), int(dict2[key]))
 
     def _assertIntArrayDictsEqual(self, dict1, dict2):
         self.assertEqual(len(dict1), len(dict1), "resulting dictionary is of different size")
-        for key in dict1.keys():
+        for key in list(dict1.keys()):
             val1 = dict1[key]
             val2 = dict2[key]
             self.assertEqual(len(val1), len(val2), "array values of different sizes")


### PR DESCRIPTION
I'm trying to add Python 3 support to pyzfs with future module, it has still supported Python 2.7.
Suppose that doing this, is this method (porting with future module) suitable? or adding a sparse compatibility layer?

## Progress

- [ ] Replace bytes string to unicode
  - [ ] Backward compatibility
- [ ] Pass all unit tests on Linux
- [ ] Pass all unit tests on FreeBSD
... etc ...

## Tests

### Linux

#### Python 2.7

```
Ran 362 tests in 21.390s

OK (skipped=40, expected failures=6)
```
#### Python 3.6

```
Ran 362 tests in 21.688s

FAILED (errors=7, skipped=65, expected failures=6)
Test failed: <unittest.runner.TextTestResult run=362 errors=7 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=362 errors=7 failures=0>
```